### PR TITLE
Fit long endos like Church Slavonic's in Details, popups

### DIFF
--- a/src/components/LangOrEndoIntro.tsx
+++ b/src/components/LangOrEndoIntro.tsx
@@ -18,7 +18,8 @@ const useStyles = makeStyles((theme: Theme) =>
       // TODO: cool if you can make this work: position: 'sticky', top: '3rem',
       fontSize: (props: StyleProps) => (props.tooLong ? '2rem' : '2.4rem'),
       [theme.breakpoints.up('sm')]: {
-        fontSize: (props: StyleProps) => (props.tooLong ? '2.6rem' : '3rem'),
+        // Safari and/or Firefox seem to need smaller font than Chrome
+        fontSize: (props: StyleProps) => (props.tooLong ? '2.3rem' : '3rem'),
       },
     },
   })

--- a/src/components/LangOrEndoIntro.tsx
+++ b/src/components/LangOrEndoIntro.tsx
@@ -9,14 +9,16 @@ export type LangOrEndoProps = {
   attribs: Pick<LangRecordSchema, 'Language' | 'Endonym' | 'Font Image Alt'>
 }
 
+// Shaky but makes long endos like Church Slavonic's fit
+type StyleProps = { tooLong: boolean }
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    // 2.4rem makes `Anashinaabemowin` fit
     detailsPanelHeading: {
       // TODO: cool if you can make this work: position: 'sticky', top: '3rem',
-      fontSize: '2.4rem',
+      fontSize: (props: StyleProps) => (props.tooLong ? '2rem' : '2.4rem'),
       [theme.breakpoints.up('sm')]: {
-        fontSize: '3rem',
+        fontSize: (props: StyleProps) => (props.tooLong ? '2.6rem' : '3rem'),
       },
     },
   })
@@ -24,13 +26,19 @@ const useStyles = makeStyles((theme: Theme) =>
 
 // Mongolian, ASL, etc. have URLs to images
 export const LangOrEndoIntro: FC<LangOrEndoProps> = (props) => {
-  const classes = useStyles()
+  const CHAR_CUTOFF = 17
   const { attribs: selFeatAttribs } = props
   const {
     Endonym,
     Language: language,
     'Font Image Alt': altImage,
   } = selFeatAttribs
+
+  const classes = useStyles({
+    // SEMI-GROSS: if there are no spaces in the Endonym and it's over the
+    // character cutoff defined above, reduce the font size
+    tooLong: !Endonym.trim().includes(' ') && Endonym.length >= CHAR_CUTOFF,
+  })
 
   return (
     <>

--- a/src/components/map/MapPopup.tsx
+++ b/src/components/map/MapPopup.tsx
@@ -14,7 +14,9 @@ const useStyles = makeStyles((theme: Theme) =>
     mapPopupRoot: {
       textAlign: 'center',
       minWidth: 150,
-      maxWidth: 260, // shaky but makes long endos like Church Slavonic's fit
+      // Shaky but makes long endos like Church Slavonic's fit. Safari and/or
+      // Firefox seem to need more room than Chrome.
+      maxWidth: 270,
       wordWrap: 'break-word',
       '& .mapboxgl-popup-content': {
         // Leave room for "x" close button

--- a/src/components/map/MapPopup.tsx
+++ b/src/components/map/MapPopup.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
     mapPopupRoot: {
       textAlign: 'center',
       minWidth: 150,
-      maxWidth: 250,
+      maxWidth: 260, // shaky but makes long endos like Church Slavonic's fit
       wordWrap: 'break-word',
       '& .mapboxgl-popup-content': {
         // Leave room for "x" close button


### PR DESCRIPTION
## Issues resolved by this pull request

Closes #94

## Summary

Kind of a gross hack but I'm okay with it since there are only 1 or 2 instances in the dataset so far. Here's the logic/check to deal with this issue:

1. If there are no spaces in the Endonym (aka single-word Endo)
1. ...and it's 17 characters or more (Church Slavonic is 19 but I dropped it down a couple just in case)
1. ...reduce the font size by 4px or so