### PR TITLE
No MB boundaries (Neighbs only so far)

### DIFF
--- a/src/components/context/MapToolsContext.tsx
+++ b/src/components/context/MapToolsContext.tsx
@@ -4,7 +4,7 @@ import * as Types from './types'
 
 const initialState = {
   autoZoomCensus: true,
-  boundariesVisible: false,
+  showNeighbs: false,
   geolocActive: false,
 } as Types.InitialMapToolsState
 
@@ -22,8 +22,12 @@ function reducer(
   switch (action.type) {
     case 'TOGGLE_CENSUS_AUTO_ZOOM':
       return { ...state, autoZoomCensus: !state.autoZoomCensus }
-    case 'SET_BOUNDARIES_VISIBLE':
-      return { ...state, boundariesVisible: action.payload }
+    case 'TOGGLE_NEIGHBORHOODS_LAYER':
+      return {
+        ...state,
+        showNeighbs:
+          action.payload === undefined ? !state.showNeighbs : action.payload,
+      }
     case 'SET_GEOLOC_ACTIVE':
       return { ...state, geolocActive: action.payload }
     case 'SET_CENSUS_FIELD':

--- a/src/components/context/MapToolsContext.tsx
+++ b/src/components/context/MapToolsContext.tsx
@@ -4,8 +4,8 @@ import * as Types from './types'
 
 const initialState = {
   autoZoomCensus: true,
-  showNeighbs: false,
   geolocActive: false,
+  showNeighbs: true, // TODO: set back
 } as Types.InitialMapToolsState
 
 const MapToolsContext = React.createContext<

--- a/src/components/context/MapToolsContext.tsx
+++ b/src/components/context/MapToolsContext.tsx
@@ -5,7 +5,7 @@ import * as Types from './types'
 const initialState = {
   autoZoomCensus: true,
   geolocActive: false,
-  showNeighbs: true, // TODO: set back
+  showNeighbs: false,
 } as Types.InitialMapToolsState
 
 const MapToolsContext = React.createContext<

--- a/src/components/context/types.ts
+++ b/src/components/context/types.ts
@@ -100,16 +100,16 @@ type CensusFieldPayload = {
 
 export type InitialMapToolsState = {
   autoZoomCensus: boolean
-  boundariesVisible: boolean
+  showNeighbs: boolean
   geolocActive: boolean
   censusActiveField?: CensusFieldPayload
 }
 
 export type MapToolsAction =
   | { type: 'CLEAR_CENSUS_FIELD' }
-  | { type: 'SET_BOUNDARIES_VISIBLE'; payload: boolean }
   | { type: 'SET_CENSUS_FIELD'; payload: CensusFieldPayload }
   | { type: 'SET_GEOLOC_ACTIVE'; payload: boolean }
+  | { type: 'TOGGLE_NEIGHBORHOODS_LAYER'; payload?: boolean }
   | { type: 'TOGGLE_CENSUS_AUTO_ZOOM' }
 
 export type MapToolsDispatch = React.Dispatch<MapToolsAction>

--- a/src/components/explore/hooks.tsx
+++ b/src/components/explore/hooks.tsx
@@ -17,7 +17,7 @@ const airtableQuery = async (tableName: string, options: AirtableOptions) => {
 }
 
 export function useAirtable<TResult = TonsOfFields>(
-  tableName: string,
+  tableName: string, // TODO: only allow actual table names!
   options: AirtableOptions,
   reactQueryOptions?: ReactQueryOptions
 ): {

--- a/src/components/map/GeocodeMarker.tsx
+++ b/src/components/map/GeocodeMarker.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-export const GeocodeMarker: FC<MapTypes.GeocodeMarker> = (props) => {
+export const GeocodeMarker: FC<MapTypes.GeocodeMarkerProps> = (props) => {
   const { latitude, longitude, text } = props
   const classes = useStyles()
 

--- a/src/components/map/GeocoderPopout.tsx
+++ b/src/components/map/GeocoderPopout.tsx
@@ -58,7 +58,7 @@ export const GeocoderPopout: FC<GeocoderPopoutProps> = (props) => {
         offset,
       }
 
-      flyToPoint(map, settings, null, text)
+      flyToPoint(map, settings, text)
     }
   }
 

--- a/src/components/map/GeocoderPopout.tsx
+++ b/src/components/map/GeocoderPopout.tsx
@@ -24,7 +24,7 @@ export const GeocoderPopout: FC<GeocoderPopoutProps> = (props) => {
   const geocoderContainerRef = React.useRef<HTMLDivElement>(null)
   const { width, height } = useWindowResize()
   const offset = useOffset(panelOpen)
-  const { boundariesVisible } = useMapToolsState()
+  const { showNeighbs } = useMapToolsState()
   const mapToolsDispatch = useMapToolsDispatch()
   const { text: placeholderText } = useUItext('loc-search-placeholder')
 
@@ -62,21 +62,21 @@ export const GeocoderPopout: FC<GeocoderPopoutProps> = (props) => {
     }
   }
 
-  const handleBoundariesToggle = () => {
+  const handleNeighborhoodsToggle = () => {
     mapToolsDispatch({
-      type: 'SET_BOUNDARIES_VISIBLE',
-      payload: !boundariesVisible,
+      type: 'TOGGLE_NEIGHBORHOODS_LAYER',
     })
   }
 
   const ControlLabel = (
     <div className={classes.controlLabel}>
-      Show neighborhoods and counties
+      Show neighborhoods
       <SimplePopover
         text={
           <>
-            Neighborhoods are shown within NYC's five boroughs, and counties for
-            the surrounding areas. <em>Source: NYC Census 2020 map</em>
+            Neighborhoods are shown within NYC's five boroughs, and counties
+            (coming soon) for the surrounding areas.{' '}
+            <em>Source: NYC Census 2020 map</em>
           </>
         }
       />
@@ -93,8 +93,8 @@ export const GeocoderPopout: FC<GeocoderPopoutProps> = (props) => {
         classes={{ label: smallerText, root: switchFormCtrlRoot }}
         control={
           <Switch
-            checked={boundariesVisible}
-            onChange={handleBoundariesToggle}
+            checked={showNeighbs}
+            onChange={handleNeighborhoodsToggle}
             name="show-welcome-switch"
             size="small"
           />

--- a/src/components/map/GeocoderPopout.tsx
+++ b/src/components/map/GeocoderPopout.tsx
@@ -48,7 +48,7 @@ export const GeocoderPopout: FC<GeocoderPopoutProps> = (props) => {
         offset,
       }
 
-      flyToBounds(map, settings, null)
+      flyToBounds(map, settings)
     } else {
       const settings = {
         latitude: center[1],

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -17,7 +17,6 @@ import { LangMbSrcAndLayer } from './LangMbSrcAndLayer'
 import { Geolocation } from './Geolocation'
 import { LanguagePopup, MapPopup } from './MapPopup'
 import { MapCtrlBtns } from './MapCtrlBtns'
-import { BoundariesLayer } from './BoundariesLayer'
 import { CensusLayer } from './CensusLayer'
 import { GeocodeMarker } from './GeocodeMarker'
 import { NeighborhoodsLayer } from './NeighborhoodsLayer'
@@ -36,7 +35,7 @@ import { onHover } from './events'
 import * as Types from './types'
 import * as utils from './utils'
 
-const { boundariesLayerIDs, langTypeIconsConfig } = config
+const { langTypeIconsConfig } = config
 
 utils.rightToLeftSetup()
 
@@ -48,9 +47,9 @@ export const Map: FC<Types.MapProps> = (props) => {
   const { panelOpen } = usePanelState()
   const { state } = useContext(contexts.GlobalContext)
   const {
-    boundariesVisible,
     autoZoomCensus,
     censusActiveField,
+    showNeighbs,
   } = contexts.useMapToolsState()
   const offset = useOffset(panelOpen)
   const breakpoint = useBreakpoint()
@@ -247,14 +246,15 @@ export const Map: FC<Types.MapProps> = (props) => {
       return // prevent boundary click underneath
     }
 
-    if (!boundariesVisible) {
+    // TODO: restore, remove or refactor. Better to just check for what's under?
+    if (!showNeighbs) {
       history.push('/Explore/Language/none')
 
       return
     }
 
     const boundariesClicked = map.queryRenderedFeatures(event.point, {
-      layers: boundariesLayerIDs,
+      layers: ['neighborhoods-poly'], // TODO: make it work for all
     }) as Types.BoundaryFeat[]
 
     if (!boundariesClicked.length) {
@@ -310,14 +310,6 @@ export const Map: FC<Types.MapProps> = (props) => {
           }}
         />
         {geocodeMarker && <GeocodeMarker {...geocodeMarker} />}
-        {[config.neighbConfig, config.countiesConfig].map((boundaryConfig) => (
-          <BoundariesLayer
-            key={boundaryConfig.source.id}
-            {...boundaryConfig}
-            visible={boundariesVisible}
-            {...{ beforeId, map, clickedBoundary }}
-          />
-        ))}
         <NeighborhoodsLayer />
         <CensusLayer
           map={map}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -20,6 +20,7 @@ import { MapCtrlBtns } from './MapCtrlBtns'
 import { BoundariesLayer } from './BoundariesLayer'
 import { CensusLayer } from './CensusLayer'
 import { GeocodeMarker } from './GeocodeMarker'
+import { NeighborhoodsLayer } from './NeighborhoodsLayer'
 
 import * as config from './config'
 import {
@@ -317,6 +318,7 @@ export const Map: FC<Types.MapProps> = (props) => {
             {...{ beforeId, map, clickedBoundary }}
           />
         ))}
+        <NeighborhoodsLayer />
         <CensusLayer
           map={map}
           config={config.pumaConfig}

--- a/src/components/map/MapPopup.tsx
+++ b/src/components/map/MapPopup.tsx
@@ -6,7 +6,7 @@ import { Typography } from '@material-ui/core'
 
 import { InstanceLevelSchema } from 'components/context'
 import { useAirtable } from 'components/explore/hooks'
-import { MapPopupProps, SetShowPopupsProps } from './types'
+import { MapPopupProps, MapPopupsProps, NeighborhoodTableSchema } from './types'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -72,7 +72,7 @@ export const MapPopup: FC<MapPopupProps> = (props) => {
   )
 }
 
-const LanguagePopup: FC<SetShowPopupsProps> = (props) => {
+const LanguagePopup: FC<Pick<MapPopupsProps, 'setShowPopups'>> = (props) => {
   const { setShowPopups } = props
   const { id } = useParams<{ id: string }>()
 
@@ -97,16 +97,7 @@ const LanguagePopup: FC<SetShowPopupsProps> = (props) => {
   )
 }
 
-export type NeighborhoodTableSchema = {
-  name: string
-  County: string // or NYC borough
-  x_max: number
-  x_min: number
-  y_min: number
-  y_max: number
-}
-
-const NeighborhoodPopup: FC<SetShowPopupsProps> = (props) => {
+const NeighborhoodPopup: FC<MapPopupsProps> = (props) => {
   const { setShowPopups } = props
   const { name } = useParams<{ name: string }>()
 
@@ -143,7 +134,7 @@ const NeighborhoodPopup: FC<SetShowPopupsProps> = (props) => {
   )
 }
 
-export const MapPopups: FC<SetShowPopupsProps> = (props) => {
+export const MapPopups: FC<MapPopupsProps> = (props) => {
   const { setShowPopups } = props
 
   return (

--- a/src/components/map/NeighborhoodsLayer.tsx
+++ b/src/components/map/NeighborhoodsLayer.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react'
 import { Source, Layer } from 'react-map-gl'
 
+import { useMapToolsState } from 'components/context'
+
 const minZoom = 8
 const sourceID = 'neighborhoods-new'
 const sourceLayer = 'neighborhoods'
@@ -20,9 +22,11 @@ const paint = {
 
 export const NeighborhoodsLayer: FC = () => {
   // const { beforeId, visible } = props
+  const { showNeighbs } = useMapToolsState()
 
   // elalliance.ckmundquc1k5328ppob5a9wok-1kglp
   // if (!visible) return null
+  if (!showNeighbs) return null
 
   return (
     <Source id={sourceID} url={url} type="vector">
@@ -33,18 +37,19 @@ export const NeighborhoodsLayer: FC = () => {
           'background-opacity': 0,
         }}
       />
-      {/* ...then use its id as the 'beforeId' for other layers. Boom. */}
-      <Layer
-        // beforeId={beforeId}
-        id="neighborhoods-poly"
-        minzoom={minZoom}
-        source-layer={sourceLayer}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        paint={paint}
-        type="fill"
-      />
-      {/* <Layer beforeId={beforeId} {...layer} layout={{ ...layer.layout }} /> */}
+      {showNeighbs ? (
+        <Layer
+          id="neighborhoods-poly"
+          minzoom={minZoom}
+          source-layer={sourceLayer}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          paint={paint}
+          type="fill"
+        />
+      ) : (
+        <></>
+      )}
     </Source>
   )
 }

--- a/src/components/map/NeighborhoodsLayer.tsx
+++ b/src/components/map/NeighborhoodsLayer.tsx
@@ -23,7 +23,7 @@ const paint = {
 }
 
 export const NeighborhoodsLayer: FC<NeighborhoodsLayerProps> = (props) => {
-  const { map } = props
+  const { map, beforeId, mapLoaded } = props
   const { showNeighbs } = useMapToolsState()
   const match = useRouteMatch<{ neighborhood: string }>({
     path: '/Explore/Neighborhood/:neighborhood',
@@ -32,21 +32,25 @@ export const NeighborhoodsLayer: FC<NeighborhoodsLayerProps> = (props) => {
   const neighborhood = match?.params.neighborhood
 
   useEffect(() => {
-    if (!map || !neighborhood) return
+    if (!map || !mapLoaded) return
 
-    map.setFeatureState(
-      {
-        sourceLayer,
-        source: sourceID,
-        id: neighborhood,
-      },
-      { selected: true }
-    )
-  }, [map, match, neighborhood])
-
-  // elalliance.ckmundquc1k5328ppob5a9wok-1kglp
-  // if (!visible) return null
-  // if (!showNeighbs) return null
+    if (neighborhood) {
+      map.setFeatureState(
+        {
+          sourceLayer,
+          source: sourceID,
+          id: neighborhood,
+        },
+        { selected: true }
+      )
+    } else {
+      map.removeFeatureState({
+        source: 'neighborhoods-new',
+        sourceLayer: 'neighborhoods',
+      })
+    }
+    // Definitely need `mapLoaded`
+  }, [map, mapLoaded, match, neighborhood])
 
   return (
     <Source
@@ -64,19 +68,28 @@ export const NeighborhoodsLayer: FC<NeighborhoodsLayerProps> = (props) => {
           'background-opacity': 0,
         }}
       />
-      {showNeighbs ? (
-        <Layer
-          id="neighborhoods-poly"
-          minzoom={minZoom}
-          source-layer={sourceLayer}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          paint={paint}
-          type="fill"
-        />
-      ) : (
-        <></>
-      )}
+      <Layer
+        id="neighborhoods-poly"
+        source={sourceID}
+        minzoom={minZoom}
+        source-layer={sourceLayer}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        paint={paint}
+        type="fill"
+        beforeId={beforeId}
+        layout={{ visibility: showNeighbs ? 'visible' : 'none' }}
+      />
+      <Layer
+        id="neighborhoods-line"
+        source={sourceID}
+        minzoom={minZoom}
+        source-layer={sourceLayer}
+        paint={{ 'line-color': 'orange', 'line-opacity': 0.4 }}
+        type="line"
+        beforeId={beforeId}
+        layout={{ visibility: showNeighbs ? 'visible' : 'none' }}
+      />
     </Source>
   )
 }

--- a/src/components/map/NeighborhoodsLayer.tsx
+++ b/src/components/map/NeighborhoodsLayer.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react'
+import { Source, Layer } from 'react-map-gl'
+
+const minZoom = 8
+const sourceID = 'neighborhoods-new'
+const sourceLayer = 'neighborhoods'
+const url = 'mapbox://elalliance.ckmundquc1k5328ppob5a9wok-1kglp'
+
+const paint = {
+  'fill-color': 'orange',
+  'fill-opacity': [
+    'case',
+    ['boolean', ['feature-state', 'selected'], false],
+    0.44,
+    ['boolean', ['feature-state', 'hover'], false],
+    0.29,
+    0.14,
+  ],
+}
+
+export const NeighborhoodsLayer: FC = () => {
+  // const { beforeId, visible } = props
+
+  // elalliance.ckmundquc1k5328ppob5a9wok-1kglp
+  // if (!visible) return null
+
+  return (
+    <Source id={sourceID} url={url} type="vector">
+      <Layer
+        id="neighbs-placeholder"
+        type="background"
+        paint={{
+          'background-opacity': 0,
+        }}
+      />
+      {/* ...then use its id as the 'beforeId' for other layers. Boom. */}
+      <Layer
+        // beforeId={beforeId}
+        id="neighborhoods-poly"
+        minzoom={minZoom}
+        source-layer={sourceLayer}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        paint={paint}
+        type="fill"
+      />
+      {/* <Layer beforeId={beforeId} {...layer} layout={{ ...layer.layout }} /> */}
+    </Source>
+  )
+}

--- a/src/components/map/NeighborhoodsLayer.tsx
+++ b/src/components/map/NeighborhoodsLayer.tsx
@@ -27,6 +27,7 @@ export const NeighborhoodsLayer: FC<NeighborhoodsLayerProps> = (props) => {
   const { showNeighbs } = useMapToolsState()
   const match = useRouteMatch<{ neighborhood: string }>({
     path: '/Explore/Neighborhood/:neighborhood',
+    exact: true,
   })
   const neighborhood = match?.params.neighborhood
 

--- a/src/components/map/NeighborhoodsLayer.tsx
+++ b/src/components/map/NeighborhoodsLayer.tsx
@@ -1,7 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
+import { useRouteMatch } from 'react-router-dom'
 import { Source, Layer } from 'react-map-gl'
 
 import { useMapToolsState } from 'components/context'
+import { NeighborhoodsLayerProps } from './types'
 
 const minZoom = 8
 const sourceID = 'neighborhoods-new'
@@ -20,16 +22,40 @@ const paint = {
   ],
 }
 
-export const NeighborhoodsLayer: FC = () => {
-  // const { beforeId, visible } = props
+export const NeighborhoodsLayer: FC<NeighborhoodsLayerProps> = (props) => {
+  const { map } = props
   const { showNeighbs } = useMapToolsState()
+  const match = useRouteMatch<{ neighborhood: string }>({
+    path: '/Explore/Neighborhood/:neighborhood',
+  })
+  const neighborhood = match?.params.neighborhood
+
+  useEffect(() => {
+    if (!map || !neighborhood) return
+
+    map.setFeatureState(
+      {
+        sourceLayer,
+        source: sourceID,
+        id: neighborhood,
+      },
+      { selected: true }
+    )
+  }, [map, match, neighborhood])
 
   // elalliance.ckmundquc1k5328ppob5a9wok-1kglp
   // if (!visible) return null
-  if (!showNeighbs) return null
+  // if (!showNeighbs) return null
 
   return (
-    <Source id={sourceID} url={url} type="vector">
+    <Source
+      id={sourceID}
+      url={url}
+      type="vector"
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore // promoteId is just not anywhere in the source...
+      promoteId="name"
+    >
       <Layer
         id="neighbs-placeholder"
         type="background"

--- a/src/components/map/config.polygons.ts
+++ b/src/components/map/config.polygons.ts
@@ -1,8 +1,6 @@
 // TODO: break out file into config.{census,neighborhoods,counties}.ts
 import * as Types from './types'
 
-// `symbol-sort-order` useful maybe:
-// https://stackoverflow.com/a/59103558/1048518
 const neighbPaint = {
   'fill-color': 'orange',
   'fill-opacity': [
@@ -15,8 +13,6 @@ const neighbPaint = {
   ],
 }
 
-// TODO: if the missing "Sheepshead Bay" polygon is added to Boundaries by MB,
-// then the lookup table for this layer will need to be updated.
 const neighbSrcID: Types.BoundariesInternalSrcID = 'neighborhoods'
 const neighbLyrSrc = {
   source: neighbSrcID,

--- a/src/components/map/config.ts
+++ b/src/components/map/config.ts
@@ -33,6 +33,7 @@ export const mapProps: InitialMapProps = {
   mapboxApiAccessToken: MAPBOX_TOKEN,
   mapOptions: { logoPosition: 'bottom-left' },
   mapStyle: isLocalDev ? blank : light, // TODO: default to blank in dev
+  // mapStyle: light, // TODO: default to blank in dev
   maxZoom: 18, // 18 is kinda misleading w/the dispersed points, but looks good
   width: '100%',
 }

--- a/src/components/map/events.ts
+++ b/src/components/map/events.ts
@@ -1,7 +1,6 @@
 import { InstanceLevelSchema } from 'components/context'
 
 import { MapboxGeoJSONFeature } from 'mapbox-gl'
-import { WebMercatorViewport } from 'react-map-gl'
 import * as utils from './utils'
 import * as MapTypes from './types'
 
@@ -77,47 +76,4 @@ export const onHoverOrig: MapTypes.OnHover = (
       { hover: true }
     )
   }
-}
-
-export const flyToClickedPolygon: MapTypes.HandleBoundaryClick = (
-  map,
-  topMostFeat,
-  boundsConfig,
-  offset
-) => {
-  utils.clearSelPolyFeats(map)
-
-  // NOTE: rather than storing bounds in the lookup tables, tried
-  // `boundaryFeat.geometry` instead. Sort of worked but since vector tiles only
-  // render what's needed, there's no guarantee the whole feature's bbox will be
-  // available in the current view. And there doesn't seem to be a way to get
-  // its full bounds other than the lookup tables. 😞
-  const {
-    x_max: xMax,
-    x_min: xMin,
-    y_min: yMin,
-    y_max: yMax,
-  } = topMostFeat.properties
-  const { width, height } = boundsConfig
-  const boundsArray = [
-    [xMin, yMin],
-    [xMax, yMax],
-  ] as MapTypes.BoundsArray
-
-  const settings = {
-    height,
-    width,
-    bounds: boundsArray,
-    padding: 50,
-    offset: offset || [0, 0],
-  }
-
-  const webMercViewport = new WebMercatorViewport({
-    width,
-    height,
-  }).fitBounds(boundsArray, { offset, padding: 75 })
-
-  utils.flyToBounds(map, settings)
-
-  return { ...webMercViewport }
 }

--- a/src/components/map/hooks.tsx
+++ b/src/components/map/hooks.tsx
@@ -126,36 +126,31 @@ const createLayerStyles = (
     },
   }))
 
-export const usePopupFeatDetails = (): Types.UsePopupFeatDetailsReturn => {
+export const useSelLangPointCoords = (): Types.UseSelLangPointCoordsReturn => {
   const match = useRouteMatch<{ id: string }>({
     path: '/Explore/Language/:language/:id',
+    exact: true,
   })
-
-  const fields: Array<Extract<keyof InstanceLevelSchema, string>> = [
-    'Language',
-    'Endonym',
-    'Latitude',
-    'Longitude',
-    'id',
-    'Font Image Alt',
-  ]
 
   const { data, error, isLoading } = useAirtable<Types.SelFeatAttribs>(
     'Data',
     {
-      fields,
+      fields: ['Latitude', 'Longitude'],
       filterByFormula: `{id} = ${match?.params.id}`,
       maxRecords: 1,
     },
     { enabled: !!match }
   )
 
-  if (isLoading || error) return { isLoading, error }
+  if (isLoading || error) return { lat: null, lon: null }
 
-  return { selFeatAttribs: data[0], error, isLoading }
+  return {
+    lat: data[0]?.Latitude || null,
+    lon: data[0]?.Longitude || null,
+  }
 }
 
-export const usePolygonWebMerc = (): Types.BoundsArray | undefined => {
+export const usePolygonWebMerc = (): Types.UsePolygonWebMerc => {
   const match = useRouteMatch<{ name: string }>({
     path: '/Explore/Neighborhood/:name',
     exact: true,
@@ -168,19 +163,20 @@ export const usePolygonWebMerc = (): Types.BoundsArray | undefined => {
       filterByFormula: `{name} = "${match?.params.name}"`,
       maxRecords: 1,
     },
-    {
-      enabled: match?.params?.name !== undefined,
-    }
+    { enabled: !!match }
   )
 
-  if (isLoading || error || !data.length) return undefined
+  if (isLoading || error || !data.length)
+    return { x_max: null, x_min: null, y_min: null, y_max: null }
 
-  const { x_max: xMax, x_min: xMin, y_min: yMin, y_max: yMax } = data[0]
+  // const { x_max: xMax, x_min: xMin, y_min: yMin, y_max: yMax } = data[0]
 
-  return [
-    [xMin, yMin],
-    [xMax, yMax],
-  ]
+  return {
+    x_max: data[0].x_max,
+    x_min: data[0].x_min,
+    y_min: data[0].y_min,
+    y_max: data[0].y_max,
+  }
 }
 
 // Fly to extent of lang features on length change

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -31,7 +31,7 @@ type SourceWithPromoteID = Omit<SourceProps, 'id'> & {
 }
 
 export type BoundsArray = [[number, number], [number, number]]
-export type GeocodeMarker = LongLat & { text: string }
+export type GeocodeMarkerProps = LongLat & { text: string }
 export type InitialMapProps = InteractiveMapProps
 export type LangIconConfig = { icon: string; id: string }
 export type LayerBasics = { 'source-layer': string; id: string }
@@ -180,9 +180,8 @@ export type BoundaryLookup = {
 }
 
 export type CustomEventData = MapEventType & {
-  popupSettings: PopupSettings | null
   forceViewportUpdate?: boolean | true
-  geocodeMarker?: GeocodeMarker
+  geocodeMarker?: GeocodeMarkerProps
 }
 
 export type PrepPopupContent = (
@@ -190,12 +189,10 @@ export type PrepPopupContent = (
   popupHeading?: string | null
 ) => PopupContent | null
 
-export type HandleBoundaryClick = (
-  map: Map,
-  topMostFeat: BoundaryFeat,
-  boundsConfig: BoundsConfig,
+export type GetPolyWebMercView = (
+  boundsArray: BoundsArray,
   offset?: [number, number]
-) => LongLat | null
+) => LongLatAndZoom
 
 export type FlyToBounds = (
   map: Map,
@@ -213,7 +210,6 @@ export type FlyToPoint = (
     pitch?: number
     offset: [number, number]
   },
-  popupContent: PopupContent | null,
   geocodeMarkerText?: string
 ) => void
 
@@ -244,8 +240,12 @@ export type UseLayersConfig = {
 }
 
 // Not a component, but shared by several
-export type SetShowPopupsProps = { setShowPopups: React.Dispatch<boolean> }
-export type MapPopupProps = PopupSettings & SetShowPopupsProps
+export type MapPopupsProps = {
+  setShowPopups: React.Dispatch<boolean>
+}
+
+export type MapPopupProps = PopupSettings &
+  Pick<MapPopupsProps, 'setShowPopups'>
 
 export type SelFeatAttribs = InternalUse &
   Pick<InstanceLevelSchema, 'Language' | 'Endonym' | 'Font Image Alt'>
@@ -266,7 +266,6 @@ export type UsePolygonCenter = (
 ) => LongLat | null
 
 export type UseZoomToLangFeatsExtent = (
-  panelOpen: boolean,
   isMapTilted: boolean,
   map?: Map
 ) => boolean
@@ -297,4 +296,13 @@ export type UsePopupFeatDetailsReturn = {
   selFeatAttribs?: SelFeatAttribs
   error: unknown
   isLoading: boolean
+}
+
+export type NeighborhoodTableSchema = {
+  name: string
+  County: string // or NYC borough
+  x_max: number
+  x_min: number
+  y_min: number
+  y_max: number
 }

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -82,7 +82,13 @@ export type BoundaryFeat = Omit<
   'properties' | 'geometry' | 'source'
 > & {
   geometry: GeoJSON.Polygon | GeoJSON.MultiPolygon
-  properties: { Name: string; ID: number }
+  properties: {
+    name: string
+    x_max: number
+    x_min: number
+    y_min: number
+    y_max: number
+  }
   source: BoundariesInternalSrcID
   'source-layer': string
 }
@@ -131,6 +137,10 @@ export type CensusLayerProps = {
   sourceLayer: string
   config: Omit<BoundaryConfig, 'lookupPath'>
   beforeId?: string
+  map?: Map
+}
+
+export type NeighborhoodsLayerProps = {
   map?: Map
 }
 
@@ -184,17 +194,15 @@ export type HandleBoundaryClick = (
   map: Map,
   topMostFeat: BoundaryFeat,
   boundsConfig: BoundsConfig,
-  lookup: BoundaryLookup[],
   offset?: [number, number]
-) => PopupSettings | null
+) => LongLat | null
 
 export type FlyToBounds = (
   map: Map,
   settings: BoundsConfig & {
     bounds: BoundsArray
     offset: [number, number]
-  },
-  popupContent: PopupContent | null
+  }
 ) => void
 
 export type FlyToPoint = (
@@ -235,9 +243,9 @@ export type UseLayersConfig = {
   error: unknown
 }
 
-export type MapPopupProps = PopupSettings & {
-  setVisible: () => void
-}
+// Not a component, but shared by several
+export type SetShowPopupsProps = { setShowPopups: React.Dispatch<boolean> }
+export type MapPopupProps = PopupSettings & SetShowPopupsProps
 
 export type SelFeatAttribs = InternalUse &
   Pick<InstanceLevelSchema, 'Language' | 'Endonym' | 'Font Image Alt'>
@@ -251,11 +259,11 @@ export type FlyToPointSettings = {
   offset: Offset
 }
 
-export type UseBoundaryPopup = (
+export type UsePolygonCenter = (
   panelOpen: boolean,
   clickedBoundary?: BoundaryFeat | null,
   map?: Map
-) => PopupSettings | null
+) => LongLat | null
 
 export type UseZoomToLangFeatsExtent = (
   panelOpen: boolean,
@@ -284,3 +292,9 @@ export type UseCensusSymb = (
   censusScope: CensusScope,
   map?: Map
 ) => UseCensusSymbReturn
+
+export type UsePopupFeatDetailsReturn = {
+  selFeatAttribs?: SelFeatAttribs
+  error: unknown
+  isLoading: boolean
+}

--- a/src/components/map/types.ts
+++ b/src/components/map/types.ts
@@ -141,6 +141,8 @@ export type CensusLayerProps = {
 }
 
 export type NeighborhoodsLayerProps = {
+  mapLoaded: boolean
+  beforeId?: string
   map?: Map
 }
 
@@ -247,8 +249,7 @@ export type MapPopupsProps = {
 export type MapPopupProps = PopupSettings &
   Pick<MapPopupsProps, 'setShowPopups'>
 
-export type SelFeatAttribs = InternalUse &
-  Pick<InstanceLevelSchema, 'Language' | 'Endonym' | 'Font Image Alt'>
+export type SelFeatAttribs = InternalUse
 
 export type FlyToPointSettings = {
   longitude: number
@@ -292,10 +293,16 @@ export type UseCensusSymb = (
   map?: Map
 ) => UseCensusSymbReturn
 
-export type UsePopupFeatDetailsReturn = {
-  selFeatAttribs?: SelFeatAttribs
-  error: unknown
-  isLoading: boolean
+export type UseSelLangPointCoordsReturn = {
+  lat: number | null
+  lon: number | null
+}
+
+export type UsePolygonWebMerc = {
+  x_max: number | null
+  x_min: number | null
+  y_min: number | null
+  y_max: number | null
 }
 
 export type NeighborhoodTableSchema = {

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -96,22 +96,16 @@ export const prepPopupContent: Types.PrepPopupContent = (
 
 export const flyToBounds: Types.FlyToBounds = (
   map,
-  { height, width, bounds, offset },
-  popupContent
+  { height, width, bounds, offset }
 ) => {
-  let popupSettings = null
-
   const webMercViewport = new WebMercatorViewport({
     width,
     height,
   }).fitBounds(bounds, { offset, padding: 75 })
   const { latitude, longitude, zoom } = webMercViewport
 
-  if (popupContent) popupSettings = { latitude, longitude, ...popupContent }
-
   map.flyTo({ essential: true, zoom, center: [longitude, latitude], offset }, {
     forceViewportUpdate: true,
-    popupSettings,
   } as Types.CustomEventData)
 }
 
@@ -178,10 +172,11 @@ export const langFeatsUnderClick: Types.LangFeatsUnderClick = (
   )
 }
 
-export const clearBoundaries: Types.ClearStuff = (map) => {
+// TODO: restore or remove
+export const clearSelPolyFeats: Types.ClearStuff = (map) => {
   map.removeFeatureState({
-    source: config.neighSrcId,
-    sourceLayer: config.neighPolyID,
+    source: 'neighborhoods-new',
+    sourceLayer: 'neighborhoods',
   })
   // }, 'hover') // NOTE: could not get this to work properly anywhere
 
@@ -258,7 +253,7 @@ export const flyHome = (
   }
 
   // TODO: prevent errors on resize-while-loading
-  flyToBounds(map, settings, null)
+  flyToBounds(map, settings)
 }
 
 export const getFlyToPointSettings = (

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -255,13 +255,13 @@ export const flyHome = (
 }
 
 export const getFlyToPointSettings = (
-  selFeatAttribs: Types.SelFeatAttribs,
+  coords: { lat: number; lon: number },
   offset: Types.Offset,
   isMapTilted: boolean
 ): Types.FlyToPointSettings => ({
   // bearing: 80, // TODO: consider it as it does add a new element of fancy
-  longitude: selFeatAttribs.Longitude,
-  latitude: selFeatAttribs.Latitude,
+  longitude: coords.lon,
+  latitude: coords.lat,
   zoom: config.POINT_ZOOM_LEVEL,
   disregardCurrZoom: true,
   pitch: isMapTilted ? 80 : 0,


### PR DESCRIPTION
Fixes #217

Most of neighborhood stuff is now free of MB Boundaries. It's hard-coded though, so census and county stuff will need to be adapted/added in another branch so we can stop straddling the neighborhoods AT stuff.

Only things hopefully left to do in neighbs (new issue!):

1. move toggle out of Search Locations into /Explore/Neighborhood and one level deeper
2. support auto zoom on initial page load when starting from something like /Explore/Neighborhood/Astoria.
3. for /Explore/Neighborhood/Something with no primary langs (???), rm the preceding text before where the cards would normally be.
4. support intro text from summary field in AT
5. show borough as subtitle in /Explore/Neighb/Something
