### PR TITLE
WP-driven content: point to ELA website content's WP instance

### DIFF
--- a/src/components/about/config.ts
+++ b/src/components/about/config.ts
@@ -1,11 +1,11 @@
 import { WpQueryKeys } from './types'
 
 export const WP_API_PAGES_ENDPOINT =
-  'https://languagemapping.org/wp-json/wp/v2/pages'
+  'https://content.endangeredlanguagealliance.org/wp-json/wp/v2/pages'
 
 export const wpQueryIDs = {
-  about: 203,
-  help: 209,
+  about: 9461,
+  help: 9518,
 } as { [key in WpQueryKeys]: number }
 
 export const HIDE_WELCOME_LOCAL_STG_KEY = 'hideWelcome'

--- a/src/components/about/utils.ts
+++ b/src/components/about/utils.ts
@@ -4,7 +4,11 @@ import { WP_API_PAGES_ENDPOINT } from './config'
 // Define a default query function that will receive the query key
 export const defaultQueryFn = async <T extends unknown>(
   key: number
-): Promise<T> => (await fetch(`${WP_API_PAGES_ENDPOINT}/${key}`)).json()
+): Promise<T> =>
+  // `password` is part of a hack to attempt to exclude/filter NYC Map pages
+  // from the ELA website's NextJS builds. It is not intended for security, so
+  // it's safe to commit.
+  (await fetch(`${WP_API_PAGES_ENDPOINT}/${key}?password=1234`)).json()
 
 // Provide the default query function to your app with defaultConfig
 export const wpQueryCache = new QueryCache({

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -103,7 +103,7 @@ export const Nav: FC = () => {
           <ListItem button dense disableGutters>
             <Link
               underline="none"
-              href="https://languagemapping.org/wp-content/uploads/2021/03/Help-Video-Script.pdf"
+              href="https://content.endangeredlanguagealliance.org/wp-content/uploads/2022/12/User-Manual.pdf"
               target="_blank"
               className={listLink}
             >


### PR DESCRIPTION
<!-- PLEASE REMOVE ANY INAPPLICABLE SECTIONS! -->

## Issues resolved by this pull request

- Fixes #292

## What to review (issue-specific)

- In the Info panel, the content for About and Help views should now be coming from the ELA WP site. Try updating something as a sanity check, then refresh the page (in the Github deploy preview, of course).
- The PDF link should now point to the ELA WP site.