### PR TITLE
Upgrade React to 16.14.0, TypeScript to 4.9.5, and refresh browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "jest-canvas-mock": "^2.2.0",
     "match-sorter": "^4.2.0",
     "material-table": "1.68.1",
-    "react": "^16.13.1",
+    "react": "^16.14.0",
     "react-device-detect": "^1.17.0",
-    "react-dom": "^16.13.1",
+    "react-dom": "^16.14.0",
     "react-icons": "^4.2.0",
     "react-map-gl": "^5.2.7",
     "react-map-gl-geocoder": "^2.0.16",
@@ -40,7 +40,7 @@
     "react-transition-group": "^4.4.1",
     "react-window": "^1.8.5",
     "simple-statistics": "^7.3.2",
-    "typescript": "3.9.5",
+    "typescript": "4.9.5",
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {

--- a/src/components/map/utils.ts
+++ b/src/components/map/utils.ts
@@ -299,6 +299,4 @@ export const getCenterOfBounds = (
 
 // CRED: geeksforgeeks.org/how-to-detect-touch-screen-device-using-javascript/
 export const isTouchEnabled = (): boolean =>
-  (window && 'ontouchstart' in window) ||
-  navigator.maxTouchPoints > 0 ||
-  navigator.msMaxTouchPoints > 0
+  (window && 'ontouchstart' in window) || navigator.maxTouchPoints > 0

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,9 +72,7 @@ export const getAllLangFeatIDs = (data: InternalUse[]): string[] =>
 // CRED:
 // www.geeksforgeeks.org/how-to-detect-touch-screen-device-using-javascript/
 export const isTouchEnabled = (): boolean =>
-  (window && 'ontouchstart' in window) ||
-  navigator.maxTouchPoints > 0 ||
-  navigator.msMaxTouchPoints > 0
+  (window && 'ontouchstart' in window) || navigator.maxTouchPoints > 0
 
 // CRED: https://stackoverflow.com/a/5574446/1048518
 export const toProperCase = (srcText: string): string =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,9 +3468,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001208"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz"
-  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
+  version "1.0.30001788"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz"
+  integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
 
 canvg@^3.0.6:
   version "3.0.7"
@@ -11019,7 +11019,7 @@ react-device-detect@^1.17.0:
   dependencies:
     ua-parser-js "^0.7.24"
 
-react-dom@^16.13.1:
+react-dom@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -11271,7 +11271,7 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.13.1:
+react@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -13035,10 +13035,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@^3.2.1, typescript@^3.9.3:
   version "3.9.7"


### PR DESCRIPTION
## Issues resolved by this pull request

None — this is phase 1 of a broader staged upgrade effort, not tied to a specific issue. Eventual goal is to add a component that allows you to see the map in different years. 

## Prerequisites

- Reviewer should run `yarn install` after checking out the branch, since
  `yarn.lock` changed.
- On Node 17+ (Netlify currently uses Node 20), `yarn start` continues to
  require `NODE_OPTIONS=--openssl-legacy-provider` until CRA is replaced.
  This PR does not change that; it will be addressed in a later phase.

## Review type

- [x] **FYI:** dependency bumps only; no UI or behavior changes intended.
- [ ] Content/copy
- [ ] Needs feedback
- [ ] Functionality
- [ ] Code

## What to review

- `package.json` / `yarn.lock`: React `16.13.1` → `16.14.0`, TypeScript
  `3.9.5` → `4.9.5`, and an updated `caniuse-lite` (via
  `npx update-browserslist-db@latest`, no `package.json` entry).
- `src/utils.ts` and `src/components/map/utils.ts`: removed the
  `navigator.msMaxTouchPoints` fallback in `isTouchEnabled`. This property
  was removed from `lib.dom.d.ts` in TypeScript 4+ and only applied to
  IE11, which has been EOL'd since 2022 and is already excluded by the
  project's `browserslist` config.
- [x] No new DevTools console errors introduced by these changes.
- [x] No visual/style changes.

## Verification

- `npx tsc --noEmit` — passes clean.
- `yarn build` — production build succeeds.
- `yarn start` — dev server compiles successfully on Node 22 with the
  legacy-openssl flag.

## What's next (out of scope for this PR)

Subsequent phases I'd like to propose in follow-up PRs:
- Phase 2: migrate off CRA (Vite or CRA 5) — drops the OpenSSL flag.
- Phase 3: React 16 → 17 → 18 (`createRoot`, strict mode).
- Phase 4: Material-UI v4 → MUI v5 + replace `material-table` and
  `react-swipeable-views` (both abandoned).
- Phase 5: React Router 5 → 6, react-query v2 → TanStack Query v5,
  react-map-gl 5 → 7, replace `react-map-gl-geocoder`.