### PR TITLE
Allow overriding Airtable base IDs via env vars

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -8,3 +8,11 @@ REACT_APP_SENTRY_ENVIRONMENT='your_sentry_env_name'
 
 # Airtable API
 REACT_APP_AIRTABLE_API_KEY='your_airtable_api_key'
+
+# Optional Airtable base overrides. If unset, the ELA production base IDs
+# hardcoded in src/components/config/api.ts are used. Contributors who do
+# not have access to the official ELA bases can duplicate the schema into
+# their own workspace and set the corresponding env var here to point the
+# local dev build at it.
+REACT_APP_AIRTABLE_BASE=''
+REACT_APP_AIRTABLE_CENSUS_BASE=''

--- a/src/components/config/api.ts
+++ b/src/components/config/api.ts
@@ -1,8 +1,10 @@
 import { RouteLocation } from './types'
 
 export const AIRTABLE_API_KEY = process.env.REACT_APP_AIRTABLE_API_KEY as string
-export const AIRTABLE_BASE = 'applPEl3BsnpuszQu'
-export const AIRTABLE_CENSUS_BASE = 'appjb6Qnp4lTNz7Gn'
+export const AIRTABLE_BASE =
+  process.env.REACT_APP_AIRTABLE_BASE || 'applPEl3BsnpuszQu'
+export const AIRTABLE_CENSUS_BASE =
+  process.env.REACT_APP_AIRTABLE_CENSUS_BASE || 'appjb6Qnp4lTNz7Gn'
 
 // TODO: get this into provider/global so it doesn't need adding every time
 export const reactQueryDefaults = {


### PR DESCRIPTION
## Issues resolved by this pull request

None — quality-of-life change for contributors who don't have access to the upstream ELA Airtable bases.

This PR is **independent** of the in-flight upgrade stack (#304, #305, #306). It targets \`master\` and can land in any order relative to those.

## Prerequisites

- No install or build behavior changes.
- No \`.env\` changes required **for anyone with access to the ELA production bases** — the defaults are the existing hardcoded IDs, so existing setups are unchanged.
- Contributors without ELA base access can now duplicate the schema into their own workspace and set \`REACT_APP_AIRTABLE_BASE\` (and optionally \`REACT_APP_AIRTABLE_CENSUS_BASE\`) in \`.env\` to point the local dev build at it.

## Review type

- [x] **FYI:** small, additive change with no behavior change in the default case.
- [ ] Content/copy
- [ ] Needs feedback
- [ ] Functionality
- [ ] Code

## What's in this PR

- \`src/components/config/api.ts\`: \`AIRTABLE_BASE\` and \`AIRTABLE_CENSUS_BASE\` now read from \`process.env.REACT_APP_AIRTABLE_BASE\` / \`REACT_APP_AIRTABLE_CENSUS_BASE\` with the existing hardcoded ELA IDs (\`applPEl3BsnpuszQu\`, \`appjb6Qnp4lTNz7Gn\`) as fallbacks. The defaults preserve current behavior.
- \`sample.env\`: document the two new optional vars with a comment explaining when a contributor would want to set them.

## Motivation

The project README already warns: *"Your setup will need to match ours, or you'll want to edit the code to your needs."* This removes the "edit the code" friction — contributors without ELA base access can now run the app locally against their own duplicated base without making a local-only code change to \`api.ts\` that has to be stashed before every push.

## Verification done locally

- \`yarn build\` — passes (CRA production build unchanged).
- With \`REACT_APP_AIRTABLE_BASE\` set in a local \`.env\`, runtime Airtable requests now target the override base; with it unset they continue to target the ELA base.

## What to review

- [ ] \`AIRTABLE_BASE\` and \`AIRTABLE_CENSUS_BASE\` still resolve to the ELA IDs when the new env vars are unset.
- [ ] No other code reaches the \`applPEl3BsnpuszQu\` / \`appjb6Qnp4lTNz7Gn\` literals directly (confirmed via grep — only \`api.ts\` referenced them).
- [ ] \`sample.env\` comment is accurate and useful.